### PR TITLE
Update Postcodes on Traineeship Vacancy Search Radius Test

### DIFF
--- a/src/SFA.DAS.RAA-V1.UITests/Project/Tests/Features/FAA/Applications/TraineeshipVacancy/RV1_FATV_01.feature
+++ b/src/SFA.DAS.RAA-V1.UITests/Project/Tests/Features/FAA/Applications/TraineeshipVacancy/RV1_FATV_01.feature
@@ -13,9 +13,9 @@ Scenario Outline: RV1_FATV_01 search for an existing traineeship vacancy
 	Then the Reviewer approves the vacancy
 	When an applicant is on the Find an Traineeship Page
 	And searched based on 'CV3 5ER'
-	Then the traineeship can be found based on 'CV34 5AG','2 miles'
-	And the traineeship can be found based on 'CV31 3PH','5 miles'
-	And the traineeship can be found based on 'CV37 0QE','10 miles'
+	Then the traineeship can be found based on 'CV3 1HX','2 miles'
+	And the traineeship can be found based on 'CV6 6GE','5 miles'
+	And the traineeship can be found based on 'CV11 6QF','10 miles'
 
 	Examples:
 		| location               | 

--- a/src/SFA.DAS.RAA-V1.UITests/Project/Tests/Features/FAA/Applications/TraineeshipVacancy/RV1_FATV_01.feature.cs
+++ b/src/SFA.DAS.RAA-V1.UITests/Project/Tests/Features/FAA/Applications/TraineeshipVacancy/RV1_FATV_01.feature.cs
@@ -102,11 +102,11 @@ this.ScenarioInitialize(scenarioInfo);
 #line 15
  testRunner.And("searched based on \'CV3 5ER\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 16
- testRunner.Then("the traineeship can be found based on \'CV34 5AG\',\'2 miles\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("the traineeship can be found based on \'CV3 1HX\',\'2 miles\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 17
- testRunner.And("the traineeship can be found based on \'CV31 3PH\',\'5 miles\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the traineeship can be found based on \'CV6 6GE\',\'5 miles\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 18
- testRunner.And("the traineeship can be found based on \'CV37 0QE\',\'10 miles\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the traineeship can be found based on \'CV11 6QF\',\'10 miles\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }


### PR DESCRIPTION
Changes to the PostCode implementation and the hardcoded postcode against the provider filling in details caused this test to fail. To make it a bit more robust, given the `AddMultipleVacancy` Method adds a static location of `CV1 2NJ` these postcodes are based off of that to give a correct search radius.