### PR TITLE
Amended to include the new confirmation page

### DIFF
--- a/src/SFA.DAS.Campaigns.UITests/Project/Tests/Pages/Employer/EmployerFavouritesPage.cs
+++ b/src/SFA.DAS.Campaigns.UITests/Project/Tests/Pages/Employer/EmployerFavouritesPage.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium;
+using SFA.DAS.Campaigns.UITests.Project.Tests.StepDefinitions;
 using TechTalk.SpecFlow;
 
 namespace SFA.DAS.Campaigns.UITests.Project.Tests.Pages.Employer
@@ -56,6 +57,12 @@ namespace SFA.DAS.Campaigns.UITests.Project.Tests.Pages.Employer
         {
             formCompletionHelper.ClickElement(Delete(objectContext.GetCourseId()));
             return new EmployerFavouritesPage(_context);
+        }
+
+        public RemoveConfirmPage DeleteApprenticeshipAndProviderFavourites()
+        {
+            formCompletionHelper.ClickElement(Delete(objectContext.GetCourseId()));
+            return new RemoveConfirmPage(_context);
         }
     }
 }

--- a/src/SFA.DAS.Campaigns.UITests/Project/Tests/Pages/Employer/RemoveConfirmPage.cs
+++ b/src/SFA.DAS.Campaigns.UITests/Project/Tests/Pages/Employer/RemoveConfirmPage.cs
@@ -1,0 +1,27 @@
+﻿using OpenQA.Selenium;
+using SFA.DAS.Campaigns.UITests.Project.Tests.Pages.Employer;
+using TechTalk.SpecFlow;
+
+namespace SFA.DAS.Campaigns.UITests.Project.Tests.StepDefinitions
+{
+    public class RemoveConfirmPage : EmployerBasePage
+    {
+        protected override string PageTitle => "REMOVE CONFIRMATION";
+
+        #region Helpers and Context
+        private readonly ScenarioContext _context;
+        #endregion
+
+        #region Page onjects
+        private By _removeButton = By.Id("continueButton");
+        #endregion
+
+        public RemoveConfirmPage(ScenarioContext context) : base(context) => _context = context;
+
+        public EmployerFavouritesPage ClickConfirmRemoveButton()
+        {
+            formCompletionHelper.ClickElement(_removeButton);
+            return new EmployerFavouritesPage(_context);
+        }
+    }
+}

--- a/src/SFA.DAS.Campaigns.UITests/Project/Tests/StepDefinitions/E2ESteps.cs
+++ b/src/SFA.DAS.Campaigns.UITests/Project/Tests/StepDefinitions/E2ESteps.cs
@@ -25,6 +25,7 @@ namespace SFA.DAS.Campaigns.UITests.Project.Tests.StepDefinitions
         private SummaryOfThisApprenticeshipPage _appsummaryPage;
         private SummaryOfThisProviderPage _providersummaryPage;
         private SignInPage _signInPage;
+        private RemoveConfirmPage _removeConfirmPage;
         private readonly CampaignsDataHelper _campaignsDataHelper;
         private readonly TabHelper _tabHelper;
         private readonly CampaignsConfig _campaignsConfig;
@@ -105,7 +106,9 @@ namespace SFA.DAS.Campaigns.UITests.Project.Tests.StepDefinitions
             foreach (var item in _campaignsDataHelper.CourseId)
             {
                 _objectContext.SetCourseId(item);
-                _empFavpage = _empFavpage.DeleteApprenticeshipFavourites();
+                EmployerFavouritesPage _empFavpage = new EmployerFavouritesPage(_context);
+                    _empFavpage.DeleteApprenticeshipAndProviderFavourites()
+                    .ClickConfirmRemoveButton();
             }
         }
 

--- a/src/SFA.DAS.Campaigns.UITests/appsettings.Environment.json
+++ b/src/SFA.DAS.Campaigns.UITests/appsettings.Environment.json
@@ -1,4 +1,4 @@
 {
-  "local_EnvironmentName": "PP",
+  "local_EnvironmentName": "TEST",
   "ProjectName": "Campaigns"
 }


### PR DESCRIPTION
The tests have been amend into include a new page and change of function how Apprenticeship and training provider are removed from the favourites.