### PR TITLE
fixed tests failing due to newAcademicYear dates/course issues

### DIFF
--- a/src/SFA.DAS.Approvals.UITests/Project/Helpers/DataHelpers/ApprenticeCourseDataHelper.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Helpers/DataHelpers/ApprenticeCourseDataHelper.cs
@@ -74,7 +74,8 @@ namespace SFA.DAS.Approvals.UITests.Project.Helpers.DataHelpers
             DateTime RandomStartDate()
             {
                 var start = now.AddMonths(1);
-                int range = (_nextAcademicYearStartDate - start).Days - 1;
+                int range = (_nextAcademicYearStartDate - start).Days;
+                range = (range > 0) ? range - 1 : 0;
                 return start.AddDays(new Random().Next(range));
             }
 

--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_06.feature
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_06.feature
@@ -3,6 +3,7 @@ Feature: AP_CoC_06
 
 @regression
 @waitingtostartapprentice
+@selectstandardcourse
 @cocscenarios
 Scenario: AP_CoC_06 Employer requests changes to cost and course After ILR match on waiting to start Apprentice and Provider approves
 	Given the Employer has approved apprentice

--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_06.feature.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_06.feature.cs
@@ -81,17 +81,19 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Features.CocJourneys
             " to start Apprentice and Provider approves")]
         [NUnit.Framework.CategoryAttribute("regression")]
         [NUnit.Framework.CategoryAttribute("waitingtostartapprentice")]
+        [NUnit.Framework.CategoryAttribute("selectstandardcourse")]
         [NUnit.Framework.CategoryAttribute("cocscenarios")]
         public virtual void AP_CoC_06EmployerRequestsChangesToCostAndCourseAfterILRMatchOnWaitingToStartApprenticeAndProviderApproves()
         {
             string[] tagsOfScenario = new string[] {
                     "regression",
                     "waitingtostartapprentice",
+                    "selectstandardcourse",
                     "cocscenarios"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("AP_CoC_06 Employer requests changes to cost and course After ILR match on waiting" +
                     " to start Apprentice and Provider approves", null, tagsOfScenario, argumentsOfScenario);
-#line 7
+#line 8
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -111,13 +113,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 8
+#line 9
  testRunner.Given("the Employer has approved apprentice", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 9
+#line 10
  testRunner.When("the Employer edits cost and course and confirm the changes after ILR match", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 10
+#line 11
  testRunner.Then("the provider can review and approve the changes", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }

--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_07.feature
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_07.feature
@@ -3,6 +3,7 @@ Feature: AP_CoC_07
 
 @regression
 @waitingtostartapprentice
+@selectstandardcourse
 @cocscenarios
 Scenario: AP_CoC_07 Provider requests changes to cost and course After ILR match on waiting to start Apprentice and Employer approves
 	Given the Employer has approved apprentice

--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_07.feature.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/CocJourneys/AP_CoC_07.feature.cs
@@ -81,17 +81,19 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Features.CocJourneys
             " to start Apprentice and Employer approves")]
         [NUnit.Framework.CategoryAttribute("regression")]
         [NUnit.Framework.CategoryAttribute("waitingtostartapprentice")]
+        [NUnit.Framework.CategoryAttribute("selectstandardcourse")]
         [NUnit.Framework.CategoryAttribute("cocscenarios")]
         public virtual void AP_CoC_07ProviderRequestsChangesToCostAndCourseAfterILRMatchOnWaitingToStartApprenticeAndEmployerApproves()
         {
             string[] tagsOfScenario = new string[] {
                     "regression",
                     "waitingtostartapprentice",
+                    "selectstandardcourse",
                     "cocscenarios"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("AP_CoC_07 Provider requests changes to cost and course After ILR match on waiting" +
                     " to start Apprentice and Employer approves", null, tagsOfScenario, argumentsOfScenario);
-#line 7
+#line 8
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -111,13 +113,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 8
+#line 9
  testRunner.Given("the Employer has approved apprentice", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 9
+#line 10
  testRunner.When("the provider edits cost and course and confirm the changes after ILR match", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 10
+#line 11
  testRunner.Then("the Employer can review and approve the changes", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }


### PR DESCRIPTION
Green built from PP:
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-environment-extension&releaseId=43321&environmentId=208860&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab