### PR TITLE
Approvals : added donotexecuteinparallel tag to the provider tests

### DIFF
--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyEmployer/AP_MF_NLE_03_ReservesFundingDynamicPause.feature
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyEmployer/AP_MF_NLE_03_ReservesFundingDynamicPause.feature
@@ -2,7 +2,6 @@
 Feature: AP_MF_NLE_03_ReservesFundingDynamicPause
 A Non Levy Employer reserves funding for an apprenticeship course when dymamic pause rule exists
 
-
 @approvals
 @regression
 @reservefunds

--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyEmployer/AP_MF_NLE_03_ReservesFundingDynamicPause.feature.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyEmployer/AP_MF_NLE_03_ReservesFundingDynamicPause.feature.cs
@@ -98,7 +98,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Features.ManageFunding.NonLevy
             argumentsOfScenario.Add("ReserveFrom", reserveFrom);
             argumentsOfScenario.Add("ReserveAllowed", reserveAllowed);
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("AP_MF_NLE_03 Non Levy Employer reserves funding when dynamic pause rule exists", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 9
+#line 8
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -118,22 +118,22 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 10
+#line 9
  testRunner.Given("the Employer logins using existing NonLevy Account", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 11
+#line 10
  testRunner.And(string.Format("a dynamic pause rule exists from {0} to {1}", monthActiveFrom, monthActiveTo), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 12
+#line 11
  testRunner.When("the Employer creates a reservation", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 13
+#line 12
  testRunner.Then(string.Format("the Employer is told that funding can be reserved from {0}", reserveFrom), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 14
+#line 13
  testRunner.And(string.Format("the Employer is given options {0}, {1} and {2} to select start date", firstMonth, secondMonth, thirdMonth), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 15
+#line 14
  testRunner.And(string.Format("the Employer is {0} to reserve funding for an apprenticeship course", reserveAllowed), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
@@ -148,7 +148,7 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists_0()
         {
-#line 9
+#line 8
 this.AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists("0", "3", "", "", "", "3", "not able", ((string[])(null)));
 #line hidden
         }
@@ -161,7 +161,7 @@ this.AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists("0", "
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists_1()
         {
-#line 9
+#line 8
 this.AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists("-1", "2", "2", "", "", "2", "able", ((string[])(null)));
 #line hidden
         }
@@ -174,7 +174,7 @@ this.AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists("-1", 
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists_2()
         {
-#line 9
+#line 8
 this.AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists("-2", "1", "1", "2", "", "1", "able", ((string[])(null)));
 #line hidden
         }
@@ -187,7 +187,7 @@ this.AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists("-2", 
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists_3()
         {
-#line 9
+#line 8
 this.AP_MF_NLE_03NonLevyEmployerReservesFundingWhenDynamicPauseRuleExists("-3", "0", "0", "1", "2", "", "able", ((string[])(null)));
 #line hidden
         }

--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyProvider/AP_MF_NLP_02_ReservesFundingDynamicPause.feature
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyProvider/AP_MF_NLP_02_ReservesFundingDynamicPause.feature
@@ -1,11 +1,11 @@
-﻿@approvals
+﻿@donotexecuteinparallel
 Feature: AP_MF_NLP_02_ReservesFundingDynamicPause
 A Non Levy Provider reserves funding for an apprenticeship course when dymamic pause rule exists
 
-
+@approvals
 @regression
 @reservefunds
-Scenario: AP_MF_NLP_02 Non Levy Provider reserves funding when dynamic pause rule exists
+Scenario Outline: AP_MF_NLP_02 Non Levy Provider reserves funding when dynamic pause rule exists
 	Given An Employer has given create reservation permission to a provider
 	And the Provider with create reservation permission logs in
 	And a dynamic pause rule exists from <MonthActiveFrom> to <MonthActiveTo>

--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyProvider/AP_MF_NLP_02_ReservesFundingDynamicPause.feature.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/ManageFunding/NonLevyProvider/AP_MF_NLP_02_ReservesFundingDynamicPause.feature.cs
@@ -21,14 +21,15 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Features.ManageFunding.NonLevy
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("AP_MF_NLP_02_ReservesFundingDynamicPause")]
-    [NUnit.Framework.CategoryAttribute("approvals")]
+    [NUnit.Framework.NonParallelizableAttribute()]
+    [NUnit.Framework.CategoryAttribute("donotexecuteinparallel")]
     public partial class AP_MF_NLP_02_ReservesFundingDynamicPauseFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
         private string[] _featureTags = new string[] {
-                "approvals"};
+                "donotexecuteinparallel"};
         
 #line 1 "AP_MF_NLP_02_ReservesFundingDynamicPause.feature"
 #line hidden
@@ -39,7 +40,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Features.ManageFunding.NonLevy
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
             TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-GB"), "Project/Tests/Features/ManageFunding/NonLevyProvider", "AP_MF_NLP_02_ReservesFundingDynamicPause", "A Non Levy Provider reserves funding for an apprenticeship course when dymamic pa" +
                     "use rule exists", ProgrammingLanguage.CSharp, new string[] {
-                        "approvals"});
+                        "donotexecuteinparallel"});
             testRunner.OnFeatureStart(featureInfo);
         }
         
@@ -80,6 +81,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Features.ManageFunding.NonLevy
         public virtual void AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists(string monthActiveFrom, string monthActiveTo, string firstMonth, string secondMonth, string thirdMonth, string reserveFrom, string reserveAllowed, string[] exampleTags)
         {
             string[] @__tags = new string[] {
+                    "approvals",
                     "regression",
                     "reservefunds"};
             if ((exampleTags != null))
@@ -144,6 +146,7 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("AP_MF_NLP_02 Non Levy Provider reserves funding when dynamic pause rule exists: 0" +
             "")]
+        [NUnit.Framework.CategoryAttribute("approvals")]
         [NUnit.Framework.CategoryAttribute("regression")]
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists_0()
@@ -156,6 +159,7 @@ this.AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists("0", "
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("AP_MF_NLP_02 Non Levy Provider reserves funding when dynamic pause rule exists: -" +
             "1")]
+        [NUnit.Framework.CategoryAttribute("approvals")]
         [NUnit.Framework.CategoryAttribute("regression")]
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists_1()
@@ -168,6 +172,7 @@ this.AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists("-1", 
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("AP_MF_NLP_02 Non Levy Provider reserves funding when dynamic pause rule exists: -" +
             "2")]
+        [NUnit.Framework.CategoryAttribute("approvals")]
         [NUnit.Framework.CategoryAttribute("regression")]
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists_2()
@@ -180,6 +185,7 @@ this.AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists("-2", 
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("AP_MF_NLP_02 Non Levy Provider reserves funding when dynamic pause rule exists: -" +
             "3")]
+        [NUnit.Framework.CategoryAttribute("approvals")]
         [NUnit.Framework.CategoryAttribute("regression")]
         [NUnit.Framework.CategoryAttribute("reservefunds")]
         public virtual void AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists_3()


### PR DESCRIPTION
made AP_MF_NLP_02NonLevyProviderReservesFundingWhenDynamicPauseRuleExists feature not to run in parallel with other features