### PR TITLE
Framework : Fix for specflow msbuild generation regression.

### DIFF
--- a/src/SFA.DAS.AggregatedEmployerDemand.UITests/SFA.DAS.AggregatedEmployerDemand.UITests.csproj
+++ b/src/SFA.DAS.AggregatedEmployerDemand.UITests/SFA.DAS.AggregatedEmployerDemand.UITests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ApprenticeCommitments.UITests/SFA.DAS.ApprenticeCommitments.UITests.csproj
+++ b/src/SFA.DAS.ApprenticeCommitments.UITests/SFA.DAS.ApprenticeCommitments.UITests.csproj
@@ -19,6 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.Approvals.ServiceBusIntegrationTests/SFA.DAS.Approvals.ServiceBusIntegrationTests.csproj
+++ b/src/SFA.DAS.Approvals.ServiceBusIntegrationTests/SFA.DAS.Approvals.ServiceBusIntegrationTests.csproj
@@ -17,6 +17,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
 		<PackageReference Include="SFA.DAS.NServiceBus" Version="16.0.21" />
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.Approvals.UITests/SFA.DAS.Approvals.UITests.csproj
+++ b/src/SFA.DAS.Approvals.UITests/SFA.DAS.Approvals.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Campaigns.UITests/SFA.DAS.Campaigns.UITests.csproj
+++ b/src/SFA.DAS.Campaigns.UITests/SFA.DAS.Campaigns.UITests.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ConsolidatedSupport.UITests/SFA.DAS.ConsolidatedSupport.UITests.csproj
+++ b/src/SFA.DAS.ConsolidatedSupport.UITests/SFA.DAS.ConsolidatedSupport.UITests.csproj
@@ -25,6 +25,7 @@
 	  </PackageReference>
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
 	  <PackageReference Include="RestEase" Version="1.5.0" />
+	  <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.EPAO.UITests/SFA.DAS.EPAO.UITests.csproj
+++ b/src/SFA.DAS.EPAO.UITests/SFA.DAS.EPAO.UITests.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.EmployerFinance.UITests/SFA.DAS.EmployerFinance.UITests.csproj
+++ b/src/SFA.DAS.EmployerFinance.UITests/SFA.DAS.EmployerFinance.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.EmployerIncentives.PaymentProcessTests/SFA.DAS.EmployerIncentives.PaymentProcessTests.csproj
+++ b/src/SFA.DAS.EmployerIncentives.PaymentProcessTests/SFA.DAS.EmployerIncentives.PaymentProcessTests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="SFA.DAS.EmploymentCheck.Types" Version="1.1.72" />
     <PackageReference Include="SFA.DAS.NServiceBus" Version="16.0.21" />
 	<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.ConfigurationBuilder\SFA.DAS.ConfigurationBuilder.csproj" />

--- a/src/SFA.DAS.EmployerIncentives.UITests/SFA.DAS.EmployerIncentives.UITests.csproj
+++ b/src/SFA.DAS.EmployerIncentives.UITests/SFA.DAS.EmployerIncentives.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.FAA.UITests/SFA.DAS.FAA.UITests.csproj
+++ b/src/SFA.DAS.FAA.UITests/SFA.DAS.FAA.UITests.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.FAT-V2.UITests/SFA.DAS.FAT-V2.UITests.csproj
+++ b/src/SFA.DAS.FAT-V2.UITests/SFA.DAS.FAT-V2.UITests.csproj
@@ -25,6 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.FAT.UITests/SFA.DAS.FAT.UITests.csproj
+++ b/src/SFA.DAS.FAT.UITests/SFA.DAS.FAT.UITests.csproj
@@ -26,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.FindEPAO.UITests/SFA.DAS.FindEPAO.UITests.csproj
+++ b/src/SFA.DAS.FindEPAO.UITests/SFA.DAS.FindEPAO.UITests.csproj
@@ -25,6 +25,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 

--- a/src/SFA.DAS.FlexiPayments.E2ETests/SFA.DAS.FlexiPayments.E2ETests.csproj
+++ b/src/SFA.DAS.FlexiPayments.E2ETests/SFA.DAS.FlexiPayments.E2ETests.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
 		<PackageReference Include="coverlet.collector" Version="3.1.2" />
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.ManagingStandards.UITests/SFA.DAS.ManagingStandards.UITests.csproj
+++ b/src/SFA.DAS.ManagingStandards.UITests/SFA.DAS.ManagingStandards.UITests.csproj
@@ -20,6 +20,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="SpecFlow.Assist.Dynamic" Version="1.4.2" />
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.PayeCreation.Tests/SFA.DAS.PayeCreation.Tests.csproj
+++ b/src/SFA.DAS.PayeCreation.Tests/SFA.DAS.PayeCreation.Tests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	 <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProvideFeedback.UITests/SFA.DAS.ProvideFeedback.UITests.csproj
+++ b/src/SFA.DAS.ProvideFeedback.UITests/SFA.DAS.ProvideFeedback.UITests.csproj
@@ -19,6 +19,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.RAA-V1.UITests/SFA.DAS.RAA-V1.UITests.csproj
+++ b/src/SFA.DAS.RAA-V1.UITests/SFA.DAS.RAA-V1.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.RAA-V2-Employer.UITests/SFA.DAS.RAA-V2-Employer.UITests.csproj
+++ b/src/SFA.DAS.RAA-V2-Employer.UITests/SFA.DAS.RAA-V2-Employer.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.RAA-V2-Provider.UITests/SFA.DAS.RAA-V2-Provider.UITests.csproj
+++ b/src/SFA.DAS.RAA-V2-Provider.UITests/SFA.DAS.RAA-V2-Provider.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.RAA-V2-QA.UITests/SFA.DAS.RAA-V2-QA.UITests.csproj
+++ b/src/SFA.DAS.RAA-V2-QA.UITests/SFA.DAS.RAA-V2-QA.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Registration.UITests/SFA.DAS.Registration.UITests.csproj
+++ b/src/SFA.DAS.Registration.UITests/SFA.DAS.Registration.UITests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SpecFlow.Assist.Dynamic" Version="1.4.2" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Roatp.UITests/SFA.DAS.Roatp.UITests.csproj
+++ b/src/SFA.DAS.Roatp.UITests/SFA.DAS.Roatp.UITests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SpecFlow.Assist.Dynamic" Version="1.4.2" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.RoatpAdmin.UITests/SFA.DAS.RoatpAdmin.UITests.csproj
+++ b/src/SFA.DAS.RoatpAdmin.UITests/SFA.DAS.RoatpAdmin.UITests.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.SupportConsole.UITests/SFA.DAS.SupportConsole.UITests.csproj
+++ b/src/SFA.DAS.SupportConsole.UITests/SFA.DAS.SupportConsole.UITests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.TestDataCleanup/SFA.DAS.TestDataCleanup.csproj
+++ b/src/SFA.DAS.TestDataCleanup/SFA.DAS.TestDataCleanup.csproj
@@ -13,6 +13,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.TransferMatching.UITests/SFA.DAS.TransferMatching.UITests.csproj
+++ b/src/SFA.DAS.TransferMatching.UITests/SFA.DAS.TransferMatching.UITests.csproj
@@ -19,6 +19,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SFA.DAS.Transfers.UITests/SFA.DAS.Transfers.UITests.csproj
+++ b/src/SFA.DAS.Transfers.UITests/SFA.DAS.Transfers.UITests.csproj
@@ -19,6 +19,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+		<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
added SpecFlow.Tools.MsBuild.Generation reference in every project so that the msbuild can generate .cs file which will be fetched by Nunit to generate test in the Test Explorer. This fix is for local execution. 