### PR TITLE
Updated selectors for Regular delivery model radio button in 

### DIFF
--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Pages/Employer/SelectDeliveryModelPage.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Pages/Employer/SelectDeliveryModelPage.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Pages.Employer
         private static By FlexiJobRadioButton => By.CssSelector("label[for=DeliveryModelFjaa]");
         private static By EditFlexiJobRadioButton => By.CssSelector("label[for=FlexiJobAgency]");
         private static By RegularRadioButton => By.CssSelector("label[for=DeliveryModelRegular]");
+        private static By EditRegularRadioButton => By.CssSelector("label[for=Regular]");
         private static By PortableFlexiJobRadioButton => By.CssSelector("label[for=DeliveryModelFlexible]");
 
         public SelectDeliveryModelPage(ScenarioContext context) : base(context) { }
@@ -53,7 +54,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Pages.Employer
 
         public EditApprenticeDetailsPage EmployerEditDeliveryModelToRegularAndContinue()
         {
-            formCompletionHelper.Click(RegularRadioButton);
+            formCompletionHelper.Click(EditRegularRadioButton);
             Continue();
             return new EditApprenticeDetailsPage(context);
         }
@@ -74,7 +75,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Pages.Employer
 
         public ProviderEditApprenticeDetailsPage ProviderEditsDeliveryModelToRegularAndSubmits()
         {
-            formCompletionHelper.Click(RegularRadioButton);
+            formCompletionHelper.Click(EditRegularRadioButton);
             Continue();
             return new ProviderEditApprenticeDetailsPage(context);
         }


### PR DESCRIPTION
Updated selectors for Regular delivery model radio button in Select Delivery Model page as tests were failing on new FJA release.

Two failing tests that were affected for ref:
FJAA_E2E_07_Provider_PostApprovalProviderChangesDMFromFlexiToRegular
FJAA_E2E_05_Employer_PostApprovalEmployerChangesDMFromFlexiToRegular

**approvals:** https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-pipeline-progress&releaseId=88020
**apprentice-commitments:** https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-pipeline-progress&releaseId=88021
**Flexi-payments:** https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-pipeline-progress&releaseId=88022
