### PR TITLE
Multi-Selector Xpath added for Select Delivery Model Page regular button

### DIFF
--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Pages/Employer/SelectDeliveryModelPage.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Pages/Employer/SelectDeliveryModelPage.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.Pages.Employer
         private static By FlexiJobRadioButton => By.CssSelector("label[for=DeliveryModelFjaa]");
         private static By EditFlexiJobRadioButton => By.CssSelector("label[for=FlexiJobAgency]");
         private static By RegularRadioButton => By.CssSelector("label[for=DeliveryModelRegular]");
-        private static By EditRegularRadioButton => By.CssSelector("label[for=DeliveryModelRegular]");
+        private static By EditRegularRadioButton => By.XPath("//label[@for='DeliveryModelRegular' or @for='Regular']");
         private static By PortableFlexiJobRadioButton => By.CssSelector("label[for=DeliveryModelFlexible]");
 
         public SelectDeliveryModelPage(ScenarioContext context) : base(context) { }


### PR DESCRIPTION
Regular button selector on Select Delivery Model page has changed a number of times back and forth from one selector to another after different deployments to PP causing two tests to fail in FJA Approvals, so adding a multi-selector to make the tests more robust.

https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-pipeline-progress&releaseId=88658