### PR TITLE
fix for editable fields change

### DIFF
--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/StepDefinitions/ChangeOfProviderSteps.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/StepDefinitions/ChangeOfProviderSteps.cs
@@ -21,6 +21,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.StepDefinitions
         private readonly ProviderLoginUser _newProviderLoginDetails;
         private readonly ProviderLoginUser _oldProviderLoginDetails;
         private readonly ApprenticeHomePageStepsHelper _apprenticeHomePageStepsHelper;
+        private const int expectedEditableFields = 7;
 
         public ChangeOfProviderSteps(ScenarioContext context)
         {
@@ -44,7 +45,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.StepDefinitions
                 .IsAddApprenticeLinkDisplayed()
                 .IsBulkUpLoadLinkDisplayed()
                 .SelectEditApprentice()
-                .ValidateEditableTextBoxes(6)
+                .ValidateEditableTextBoxes(expectedEditableFields)
                 .EditCopApprenticeDetails()
                 .SubmitApprove();
         }
@@ -134,7 +135,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.StepDefinitions
                 .IsAddApprenticeLinkDisplayed()
                 .IsBulkUpLoadLinkDisplayed()
                 .SelectEditApprentice()
-                .ValidateEditableTextBoxes(6)
+                .ValidateEditableTextBoxes(expectedEditableFields)
                 .EditCopApprenticeDetails()
                 .SubmitApprove();
         }
@@ -207,7 +208,7 @@ namespace SFA.DAS.Approvals.UITests.Project.Tests.StepDefinitions
 
         private void ValidateOnlyEditableApprenticeDetails(EditApprenticeDetailsPage editApprenticePage)
         {
-            Assert.IsTrue(editApprenticePage.GetAllEditableBoxes().Count == 6, "validate that cohort is editable on View apprentice details page");
+            Assert.IsTrue(editApprenticePage.GetAllEditableBoxes().Count == expectedEditableFields, "validate that cohort is editable on View apprentice details page");
         }
     }
 }


### PR DESCRIPTION
2 failures in this run are not relevant and intermittent failures. Passed on local run.
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-environment-extension&releaseId=90076&environmentId=431182&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab

failures passed on rerun: https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?releaseId=90088&_a=release-environment-extension&environmentId=431241&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab