### PR TITLE
Fix Regression Test failure caused by QF-503

### DIFF
--- a/src/SFA.DAS.EPAO.UITests/Project/Tests/Pages/EPAOWithdrawalPages/AS_WhatAreYouWithdrawingFromPage.cs
+++ b/src/SFA.DAS.EPAO.UITests/Project/Tests/Pages/EPAOWithdrawalPages/AS_WhatAreYouWithdrawingFromPage.cs
@@ -5,8 +5,8 @@ public class AS_WhatAreYouWithdrawingFromPage : EPAO_BasePage
     protected override string PageTitle => "What are you withdrawing from?";
 
     #region Locators
-    private static By AssessingASpecificStandardRaidoButton => By.XPath("//*[@id='TypeOfWithdrawal']");
-    private static By TheRegisterOfEPAOrganisationsRaidoButton => By.Id("TypeOfWithdrawal-2");
+    private static By AssessingASpecificStandardRaidoButton => By.XPath("//*[@id='withdrawal-type-standard']");
+    private static By TheRegisterOfEPAOrganisationsRaidoButton => By.Id("withdrawal-type-register");
     #endregion
 
     public AS_WhatAreYouWithdrawingFromPage(ScenarioContext context) : base(context) => VerifyPage();

--- a/src/SFA.DAS.EPAO.UITests/Project/Tests/Pages/EPAOWithdrawalPages/AS_WhichStandardDoYouWantToWithdrawFromAssessingPage.cs
+++ b/src/SFA.DAS.EPAO.UITests/Project/Tests/Pages/EPAOWithdrawalPages/AS_WhichStandardDoYouWantToWithdrawFromAssessingPage.cs
@@ -8,7 +8,7 @@ public class AS_CheckWithdrawalRequestPage : EPAO_BasePage
 
     public AS_WithdrawalRequestOverviewPage ContinueWithWithdrawalRequest()
     {
-        formCompletionHelper.ClickElement(() => pageInteractionHelper.FindElement(By.CssSelector("#yes")));
+        formCompletionHelper.ClickElement(() => pageInteractionHelper.FindElement(By.CssSelector("#confirm-withdrawal-request")));
 
         Continue();
 


### PR DESCRIPTION
Changes were required to the regressin tests due to ticket "QF-503 Accessibility Updates Combinded"

There was some id's changed to align with accessibility standards.

The following tests will be resolved:
 
![Screenshot_20230222_014303](https://user-images.githubusercontent.com/118756835/220640763-ef975cb5-fd83-4555-bf1c-7767161b8209.png)
