### PR TITLE
Framework : Accessibility page title checker

### DIFF
--- a/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/TestDataPreparation/AP_CA_01_CreateAccountForApprovals.feature.cs
+++ b/src/SFA.DAS.Approvals.UITests/Project/Tests/Features/TestDataPreparation/AP_CA_01_CreateAccountForApprovals.feature.cs
@@ -93,7 +93,7 @@ this.ScenarioInitialize(scenarioInfo);
             {
                 this.ScenarioStart();
 #line 7
- testRunner.Given("an User Account is created", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+ testRunner.Given("a User Account is created", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 8
  testRunner.When("the User adds PAYE details", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
@@ -128,7 +128,7 @@ this.ScenarioInitialize(scenarioInfo);
             {
                 this.ScenarioStart();
 #line 14
- testRunner.Given("an User Account is created", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+ testRunner.Given("a User Account is created", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 15
  testRunner.When("the User adds PAYE details", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");

--- a/src/SFA.DAS.UI.Framework/TestSupport/AnalyzePageHelper.cs
+++ b/src/SFA.DAS.UI.Framework/TestSupport/AnalyzePageHelper.cs
@@ -1,15 +1,36 @@
 ﻿using OpenQA.Selenium;
-using SFA.DAS.UI.FrameworkHelpers;
-using TechTalk.SpecFlow;
-using System.Linq;
+using Selenium.Axe;
 using SFA.DAS.ConfigurationBuilder;
 using SFA.DAS.FrameworkHelpers;
-using Selenium.Axe;
 using SFA.DAS.TestDataExport;
+using SFA.DAS.UI.FrameworkHelpers;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using TechTalk.SpecFlow;
 
 namespace SFA.DAS.UI.Framework.TestSupport
 {
+    public static class AccessibilityPageTitleChecker
+    {
+        private static readonly List<string> pageTitles;
+
+        static AccessibilityPageTitleChecker()
+        {
+            pageTitles = new();
+        }
+
+        public static bool Contains(string title)
+        {
+            var x = pageTitles.Contains(title);
+
+            if (x == false) pageTitles.Add(title);
+
+            return x;
+        }
+    }
+
+
     public class AnalyzePageHelper
     {
         #region Helpers and Context
@@ -62,7 +83,7 @@ namespace SFA.DAS.UI.Framework.TestSupport
 
         private bool ShouldNotAnalyzePageCheckUsingPageTitle(string pageTitle)
         {
-            var x = _objectContext.GetAccessibilityPageTitles().Contains(pageTitle);
+            var x = AccessibilityPageTitleChecker.Contains(pageTitle);
 
             var message = x ? $"'{pageTitle}' already analyzed." : $"'{pageTitle}' not analyzed.";
 
@@ -78,12 +99,12 @@ namespace SFA.DAS.UI.Framework.TestSupport
 
             var url = _context.Get<PageInteractionHelper>().GetUrl();
 
-            if (analyzedPages.Any(x=> x.Contains(url))) return false;
+            if (analyzedPages.Any(x => x.Contains(url))) return false;
 
             var urlsplit = url.Split("?");
 
             if (urlsplit.Any() && analyzedPages.Any(x => x.Contains(urlsplit[0]))) return false;
-            
+
             return true;
         }
 


### PR DESCRIPTION
A minor change to the accessibility code not to repeat analysing the same page again in the same test execution (it only works with same dll)

![image](https://github.com/SkillsFundingAgency/das-enterprise-automation-test-suite/assets/11176423/869f4b63-690a-4144-b25c-2349cde21ef5)
