### PR TITLE
P2 - 2714 - ApprenticeFeedbackSqlHelper - Updated CreateApprenticeProviderFeedback

### DIFF
--- a/src/SFA.DAS.ProvideFeedback.UITests/Project/Helpers/ApprenticeFeedbackSqlHelper.cs
+++ b/src/SFA.DAS.ProvideFeedback.UITests/Project/Helpers/ApprenticeFeedbackSqlHelper.cs
@@ -31,6 +31,7 @@ public class ApprenticeFeedbackSqlHelper(ObjectContext objectContext, DbConfig c
         DELETE FROM ProviderAttribute WHERE ApprenticeFeedbackResultId IN (SELECT Id FROM ApprenticeFeedbackResult WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn}));
         DELETE FROM ApprenticeFeedbackResult WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn});
         DELETE FROM FeedbackTransactionClick WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn});
+        DELETE FROM FeedbackTarget WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn});
         DELETE FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn};
         ";
 

--- a/src/SFA.DAS.ProvideFeedback.UITests/Project/Helpers/ApprenticeFeedbackSqlHelper.cs
+++ b/src/SFA.DAS.ProvideFeedback.UITests/Project/Helpers/ApprenticeFeedbackSqlHelper.cs
@@ -31,7 +31,7 @@ public class ApprenticeFeedbackSqlHelper(ObjectContext objectContext, DbConfig c
         DELETE FROM ProviderAttribute WHERE ApprenticeFeedbackResultId IN (SELECT Id FROM ApprenticeFeedbackResult WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn}));
         DELETE FROM ApprenticeFeedbackResult WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn});
         DELETE FROM FeedbackTransactionClick WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn});
-        DELETE FROM FeedbackTarget WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn});
+        DELETE FROM FeedbackTransaction WHERE ApprenticeFeedbackTargetId IN (SELECT Id FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn});
         DELETE FROM ApprenticeFeedbackTarget WHERE Ukprn = {ukprn};
         ";
 


### PR DESCRIPTION
Added delete from FeedbackTransaction Statement to the sql query, to cope with a new foreign key constraint on FeedbackTransaction (ApprenticeFeedbackTargetId -> ApprenticeFeedbackTarget.Id)